### PR TITLE
BUGFIX: only use `toString` for GET requests

### DIFF
--- a/lib/private.js
+++ b/lib/private.js
@@ -45,10 +45,10 @@ class Private {
               'Content-Type': 'application/x-www-form-urlencoded'
             },
         };
-        data = new URLSearchParams(data).toString();
+        data = new URLSearchParams(data);
         let path = `/${API_ROOT}/${V1_API}/${resource}`;
         if (Private.HTTP_GET === method) {
-            path = `${path}?${data}`;
+            path = `${path}?${data.toString()}`;
         } else {
             request.body = data;
         }

--- a/lib/request.js
+++ b/lib/request.js
@@ -1,7 +1,7 @@
 'use strict';
 
 var
-    https = require('https'),
+    fetch = require('node-fetch'),
     {
         KlaviyoApiError,
         KlaviyoAuthenticationError,
@@ -38,42 +38,22 @@ class Request {
 
         headers['User-Agent'] = `Klaviyo-Node.js/${PACKAGE_VERSION}`;
 
+        const fullPath = `https://${KLAVIYO_API_HOSTNAME}/${path}`;
         const options = {
-            hostname: KLAVIYO_API_HOSTNAME,
             port: HTTPS_PORT,
-            path: path,
             method: method,
             headers: headers,
             timeout: 10000 //maybe make this a configurable value?
         };
+        if (method !== DEFAULT_HTTP_VERB && body) {
+          options.body = body;
+        }
 
         return new Promise((resolve, reject) => {
-            const request = https.request(options, (response) => {
-                let data = [];
-
-                response.on('data', chunk => {
-                    data.push(chunk);
-                });
-
-                response.on('end', () => {
-                    data = processBuffer(data);
-                    try {
-                        data = handleResponse(response, data);
-                    } catch (error) {
-                        reject(error);
-                    } finally {
-                        resolve(data);
-                    }
-                });
-            });
-
-            request.on('error', reject);
-
-            if (body) {
-                request.write(body);
-            }
-
-            request.end();
+            fetch(fullPath, options)
+                .then((response) => handleResponse(response))
+                .then((data) => resolve(data))
+                .catch((error) => reject(error));
         });
     }
 
@@ -87,27 +67,18 @@ class Request {
     }
 }
 
-function processBuffer(data = []) {
-    if (!data[0]) {
-        data = '{}';
-    } else {
-        data = Buffer.concat(data);
-    }
-    return data;
-}
-
-function handleResponse(response, data) {
-    const statusCode = response.statusCode;
-    if (statusCode == 403) {
-        throw new KlaviyoAuthenticationError(statusCode, data);
+function handleResponse(response) {
+    const statusCode = response.status;
+    if (response.ok) {
+        return response.json();
+    } else if (statusCode == 403) {
+        throw new KlaviyoAuthenticationError(statusCode, response.json());
     } else if (statusCode == 429) {
-        throw new KlaviyoRateLimitError(statusCode, data, Number(response.headers['retry-after']));
+        throw new KlaviyoRateLimitError(statusCode, response.json(), Number(response.headers['retry-after']));
     } else if (statusCode == 500 || statusCode == 503) {
-        throw new KlaviyoServerError(statusCode, data);
-    } else if (statusCode != 200 && statusCode != 202) {
-        throw new KlaviyoApiError(statusCode, data);
+        throw new KlaviyoServerError(statusCode, response.json());
     } else {
-        return JSON.parse(data);
+        throw new KlaviyoApiError(statusCode, response.json());
     }
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
-  "name": "node-klaviyo",
-  "version": "1.3.0",
+  "name": "@ruelala/node-klaviyo",
+  "version": "1.3.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "node-klaviyo",
-  "version": "1.3.0",
+  "name": "@ruelala/node-klaviyo",
+  "version": "1.3.1",
   "description": "Klaviyo API wrapper",
   "main": "./lib/klaviyo.js",
   "scripts": {
@@ -9,16 +9,18 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/klaviyo/node-klaviyo.git"
+    "url": "git+https://github.com/ruelala/node-klaviyo.git"
   },
   "keywords": [],
   "author": "",
   "license": "ISC",
   "bugs": {
-    "url": "https://github.com/klaviyo/node-klaviyo/issues"
+    "url": "https://github.com/ruelala/node-klaviyo/issues"
   },
-  "homepage": "https://github.com/klaviyo/node-klaviyo#readme",
-  "dependencies": {},
+  "homepage": "https://github.com/ruelala/node-klaviyo#readme",
+  "peerDependencies": {
+    "node-fetch": "^2.6.1"
+  },
   "devDependencies": {
     "chai": "^4.2.0",
     "chai-as-promised": "^7.1.1",

--- a/test/unit/klaviyo.js
+++ b/test/unit/klaviyo.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const
-    Klaviyo = require('node-klaviyo'),
+    Klaviyo = require('../../lib/klaviyo'),
     {
         KlaviyoError,
         KlaviyoConfigurationError

--- a/test/unit/private.js
+++ b/test/unit/private.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const
-    Klaviyo = require('node-klaviyo'),
+    Klaviyo = require('../../lib/klaviyo'),
     {
         KlaviyoError
     } = require('../../lib/errors.js'),

--- a/test/unit/profiles.js
+++ b/test/unit/profiles.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const
-    Klaviyo = require('node-klaviyo'),
+    Klaviyo = require('../../lib/klaviyo'),
     {
         KlaviyoError
     } = require('../../lib/errors.js'),
@@ -99,7 +99,7 @@ describe('Profiles', function () {
                     .query(query)
                     .reply(200, profileData);
 
-                KlaviyoClient.profiles.updateProfile({ 
+                KlaviyoClient.profiles.updateProfile({
                     profileId: fakeProfileId,
                     properties: {
                         myCustomProperty: true
@@ -131,7 +131,7 @@ describe('Profiles', function () {
                     .query(query)
                     .reply(200, timelineData);
 
-                KlaviyoClient.profiles.getProfileMetricsTimeline({ 
+                KlaviyoClient.profiles.getProfileMetricsTimeline({
                     profileId: fakeProfileId,
                     since: nowTimestamp
                 }).should.eventually.eql(timelineData);
@@ -161,7 +161,7 @@ describe('Profiles', function () {
                     .query(query)
                     .reply(200, timelineData);
 
-                KlaviyoClient.profiles.getProfileMetricsTimelineById({ 
+                KlaviyoClient.profiles.getProfileMetricsTimelineById({
                     profileId: fakeProfileId,
                     metricId: fakeMetricId,
                     since: nowTimestamp

--- a/test/unit/public.js
+++ b/test/unit/public.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const
-    Klaviyo = require('node-klaviyo'),
+    Klaviyo = require('../../lib/klaviyo'),
     {
         KlaviyoError
     } = require('../../lib/errors.js'),
@@ -75,7 +75,7 @@ describe('Public', function () {
                         encodedQueryParams: true
                     })
                     .get('/api/identify')
-                    .query(queryObject => { 
+                    .query(queryObject => {
                         const decoded = JSON.parse(Buffer.from(queryObject.data, 'base64').toString('ascii'));
                         return deepEqual(decoded, data) && queryObject.test == 0;
                     })
@@ -100,7 +100,7 @@ describe('Public', function () {
                         encodedQueryParams: true
                     })
                     .get('/api/identify')
-                    .query(queryObject => { 
+                    .query(queryObject => {
                         const decoded = JSON.parse(Buffer.from(queryObject.data, 'base64').toString('ascii'));
                         return deepEqual(decoded, data) && queryObject.test == 0;
                     })
@@ -127,7 +127,7 @@ describe('Public', function () {
                         encodedQueryParams: true
                     })
                     .get('/api/identify')
-                    .query(queryObject => { 
+                    .query(queryObject => {
                         const decoded = JSON.parse(Buffer.from(queryObject.data, 'base64').toString('ascii'));
                         return deepEqual(decoded, data) && queryObject.test == 1;
                     })
@@ -174,7 +174,7 @@ describe('Public', function () {
                         encodedQueryParams: true
                     })
                     .get('/api/track')
-                    .query(queryObject => { 
+                    .query(queryObject => {
                         const decoded = JSON.parse(Buffer.from(queryObject.data, 'base64').toString('ascii'));
                         return deepEqual(decoded, data) && queryObject.test == 0;
                     })
@@ -202,7 +202,7 @@ describe('Public', function () {
                         encodedQueryParams: true
                     })
                     .get('/api/track')
-                    .query(queryObject => { 
+                    .query(queryObject => {
                         const decoded = JSON.parse(Buffer.from(queryObject.data, 'base64').toString('ascii'));
                         return deepEqual(decoded, data) && queryObject.test == 0;
                     })
@@ -232,7 +232,7 @@ describe('Public', function () {
                         encodedQueryParams: true
                     })
                     .get('/api/track')
-                    .query(queryObject => { 
+                    .query(queryObject => {
                         const decoded = JSON.parse(Buffer.from(queryObject.data, 'base64').toString('ascii'));
                         return deepEqual(decoded, data) && queryObject.test == 1;
                     })
@@ -264,7 +264,7 @@ describe('Public', function () {
                         encodedQueryParams: true
                     })
                     .get('/api/track')
-                    .query(queryObject => { 
+                    .query(queryObject => {
                         const decoded = JSON.parse(Buffer.from(queryObject.data, 'base64').toString('ascii'));
                         return deepEqual(decoded, data) && queryObject.test == 0;
                     })
@@ -315,7 +315,7 @@ describe('Public', function () {
                         encodedQueryParams: true
                     })
                     .get('/api/track')
-                    .query(queryObject => { 
+                    .query(queryObject => {
                         const decoded = JSON.parse(Buffer.from(queryObject.data, 'base64').toString('ascii'));
                         return deepEqual(decoded, data) && queryObject.test == 0;
                     })
@@ -347,7 +347,7 @@ describe('Public', function () {
                         encodedQueryParams: true
                     })
                     .get('/api/track')
-                    .query(queryObject => { 
+                    .query(queryObject => {
                         const decoded = JSON.parse(Buffer.from(queryObject.data, 'base64').toString('ascii'));
                         return deepEqual(decoded, data) && queryObject.test == 1;
                     })
@@ -381,7 +381,7 @@ describe('Public', function () {
                         encodedQueryParams: true
                     })
                     .get('/api/track')
-                    .query(queryObject => { 
+                    .query(queryObject => {
                         const decoded = JSON.parse(Buffer.from(queryObject.data, 'base64').toString('ascii'));
                         return deepEqual(decoded, data) && queryObject.test == 0;
                     })
@@ -397,11 +397,11 @@ describe('Public', function () {
 function deepEqual(object1, object2) {
     const keys1 = Object.keys(object1);
     const keys2 = Object.keys(object2);
-  
+
     if (keys1.length !== keys2.length) {
       return false;
     }
-  
+
     for (const key of keys1) {
       const val1 = object1[key];
       const val2 = object2[key];
@@ -413,7 +413,7 @@ function deepEqual(object1, object2) {
         return false;
       }
     }
-  
+
     return true;
 }
 


### PR DESCRIPTION
Main issue: Fix use of URLSearchParams for 'x-www-form-encoded' data;
  * Calling `toString` for for data was encoding things that were not decoded
    by the receiving API
  * NOT calling `toString` was not acceptable to the `https` module
  * Add `node-fetch` to peer dependencies for lightweight, Promise-based HTTPS
    requests
Additional issues:
  * Fix package.json for publishing to NPM
  * Change path to `Klaviyo` class in tests because the library name had changed